### PR TITLE
Don't serve the old assessment item path

### DIFF
--- a/debian/debian/kalite.conf
+++ b/debian/debian/kalite.conf
@@ -32,10 +32,6 @@ server {
         alias   $kalite_home/content/;
     }
 
-    location /content/assessment/khan {
-        alias   /usr/share/kalite/assessment/khan/;
-    }
-
     location /favicon.ico {
         empty_gif;
     }


### PR DESCRIPTION
## Summary

We've been serving this as an assumption that the user would download an assessment item pack during debconf execution.

This is no longer relevant and actually blocks serving the right folder :)
