### PR TITLE
Update KA Lite OS X installer documentation for 0.17.x release

### DIFF
--- a/osx/KA-Lite-Packages/docs/README.rst.rtf
+++ b/osx/KA-Lite-Packages/docs/README.rst.rtf
@@ -38,7 +38,7 @@ Other known issues:\
 \b0 \
 \
 \pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural\partightenfactor0
-\ls3\ilvl0\cf0 {\listtext	\'95	}NEW - We've used "KALITE_PEX" environment variables to get the path of `kalite.pex` executable.\
+\ls3\ilvl0\cf0 {\listtext	\'95	}NEW - We've used "KALITE_PEX" environment variable to get the path of `kalite.pex` executable.\
 {\listtext	\'95	}NEW - We've used bundled `kalite.pex` executable.\
 {\listtext	\'95	}NEW - KA Lite application will not start if port 8008 is not available.\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0

--- a/osx/KA-Lite-Packages/docs/README.rst.rtf
+++ b/osx/KA-Lite-Packages/docs/README.rst.rtf
@@ -2,11 +2,10 @@
 {\fonttbl\f0\fswiss\fcharset0 Helvetica;}
 {\colortbl;\red255\green255\blue255;}
 {\*\listtable{\list\listtemplateid1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{decimal\}.}{\leveltext\leveltemplateid1\'02\'00.;}{\levelnumbers\'01;}\fi-360\li720\lin720 }{\listname ;}\listid1}
-{\list\listtemplateid2\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{disc\}}{\leveltext\leveltemplateid101\'01\uc0\u8226 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{hyphen\}}{\leveltext\leveltemplateid102\'01\uc0\u8259 ;}{\levelnumbers;}\fi-360\li1440\lin1440 }{\listname ;}\listid2}
+{\list\listtemplateid2\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{disc\}}{\leveltext\leveltemplateid101\'01\uc0\u8226 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listname ;}\listid2}
 {\list\listtemplateid3\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{disc\}}{\leveltext\leveltemplateid201\'01\uc0\u8226 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listname ;}\listid3}
-{\list\listtemplateid4\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{disc\}}{\leveltext\leveltemplateid301\'01\uc0\u8226 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listname ;}\listid4}
-{\list\listtemplateid5\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{disc\}}{\leveltext\leveltemplateid401\'01\uc0\u8226 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listname ;}\listid5}}
-{\*\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}{\listoverride\listid2\listoverridecount0\ls2}{\listoverride\listid3\listoverridecount0\ls3}{\listoverride\listid4\listoverridecount0\ls4}{\listoverride\listid5\listoverridecount0\ls5}}
+{\list\listtemplateid4\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{disc\}}{\leveltext\leveltemplateid301\'01\uc0\u8226 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listname ;}\listid4}}
+{\*\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}{\listoverride\listid2\listoverridecount0\ls2}{\listoverride\listid3\listoverridecount0\ls3}{\listoverride\listid4\listoverridecount0\ls4}}
 \margl1440\margr1440\vieww28220\viewh16280\viewkind0
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 
@@ -26,67 +25,28 @@ Other known issues:\
 \b Mac Installer
 \b0 \
 \pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural\partightenfactor0
-\ls2\ilvl0\cf0 {\listtext	\'95	}NEW - We now support Mac OS X 10.11 El Capitan.\
-{\listtext	\'95	}NEW - We now use a .pkg installer which uses a setup wizard GUI.\
-{\listtext	\'95	}NEW - We now bundle the `KA-Lite.app`, `README.md`, `LICENSE`, `RELEASE_NOTES.md`, `KA-Lite_Uninstall.tool` script, and the `support` folder inside the `/Applications/KA-Lite/` folder.\
-{\listtext	\'95	}NEW - We now auto-load the application after installation.\
-{\listtext	\'95	}NEW - We now check if KA Lite is loaded and will not continue with the installation if it is.\
-{\listtext	\'95	}NEW - You can now use the `Console` utility application to view the KA-Lite installer and application logs.\
-{\listtext	\'95	}NEW - We now have a pre-installation script that checks for a previous installation if it exists and does the following:\
-\pard\tx940\tx1440\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li1440\fi-1440\pardirnatural\partightenfactor0
-\ls2\ilvl1\cf0 {\listtext	\uc0\u8259 	}Remove `/Applications/KA-Lite/KA-Lite.app`.\
-{\listtext	\uc0\u8259 	}Remove `/Applications/KA-Lite-Monitor.app`.\
-{\listtext	\uc0\u8259 	}Remove `/Library/LaunchAgents/org.learningequality.kalite.plist`.\
-{\listtext	\uc0\u8259 	}Remove `/usr/bin/kalite` executable.\
-{\listtext	\uc0\u8259 	}Remove `/usr/local/bin/kalite` executable. \
-{\listtext	\uc0\u8259 	}Remove `/Applications/KA-Lite/` directory and its contents.\
-{\listtext	\uc0\u8259 	}Unset `KALITE_PYTHON` environment variable.\
-{\listtext	\uc0\u8259 	}Unset `KALITE_HOME` environment variable.\
+\ls2\ilvl0\cf0 {\listtext	\'95	}NEW - We now support macOS Sierra.\
+{\listtext	\'95	}NEW - We now require Python version 2.7.12 or higher to install KA Lite.\
 \pard\tx220\tx720\tx1120\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural\partightenfactor0
-\ls2\ilvl0\cf0 {\listtext	\'95	}NEW - We now have a post-installation script that does the following:\
-\pard\tx940\tx1440\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li1440\fi-1440\pardirnatural\partightenfactor0
-\ls2\ilvl1\cf0 {\listtext	\uc0\u8259 	}Set `KALITE_PYTHON` environment variable.\
-{\listtext	\uc0\u8259 	}Symlink `kalite` executable to `/usr/local/bin/`.\
-{\listtext	\uc0\u8259 	}Bundle `KA-Lite.app`, `README.md`, `LICENSE`, `RELEASE_NOTES.md`, `KA-Lite_Uninstall.tool` script, and the `support` folder in the `/Applications/KA-Lite/` directory.\
-{\listtext	\uc0\u8259 	}Put the `content/contentpacks/en.zip`, `pyrun`, and `scripts` inside the `/Applications/KA-Lite/support/` folder to be used as KA Lite installer resources.\
-{\listtext	\uc0\u8259 	}Run `kalite manage` commands like `syncdb --noinput`, `retrievecontentpack`, and `setup --noinput`.\
-{\listtext	\uc0\u8259 	}Auto-load the KA Lite application after a successful installation.\
-\pard\tx220\tx720\tx1120\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural\partightenfactor0
-\ls2\ilvl0\cf0 {\listtext	\'95	}REMOVED - We don't produce and use the `.dmg` disk image anymore.\
-{\listtext	\'95	}REMOVED - We removed the word `Monitor` in the installer name.\
+\ls2\ilvl0\cf0 {\listtext	\'95	}REMOVED - We removed `Pyrun` from the KA Lite installer.\
+\pard\tx566\tx1120\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
+\cf0 \
 \pard\tx560\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \
-\
 
 \b Mac Application
 \b0 \
 \
 \pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural\partightenfactor0
-\ls3\ilvl0\cf0 {\listtext	\'95	}NEW - User can now auto-load the application on login.\
-{\listtext	\'95	}NEW - We now auto-start the KA Lite web server when the application is loaded.\
-{\listtext	\'95	}NEW - We have streamlined the preferences dialog and show only the relevant options.\
-{\listtext	\'95	}NEW - User can now set a custom KA Lite data path, instead of the default `~/.kalite/`.\
-{\listtext	\'95	}FIXED - The startup time of the KA Lite server has been greatly reduced to just a few seconds.\
-{\listtext	\'95	}FIXED - We only load the `KA-Lite.app` if the `kalite` executable is available.\
-{\listtext	\'95	}FIXED - We now use the same version as the KA Lite web application for consistency.\
-{\listtext	\'95	}CHANGED - We changed `KA-Lite-Monitor.app` to `KA-Lite.app`.\
-{\listtext	\'95	}REMOVED - We removed the "Monitor" text from the application.\
-{\listtext	\'95	}REMOVED - We removed the `Advanced` tab and its contents.\
-{\listtext	\'95	}REMOVED - We removed the automatic creation of admin account during setup.\
-\pard\tx560\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
-\cf0  \
-\
-
-\b Mac Uninstaller
-\b0 \
-\pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural\partightenfactor0
-\ls4\ilvl0\cf0 {\listtext	\'95	}NEW - User can uninstall `KA-Lite.app` and it's dependencies using the `KA-Lite_Uninstall.tool` script.\
-{\listtext	\'95	}NEW - User can optionally delete the `~/.kalite/` folder or the custom KA Lite data path.\
+\ls3\ilvl0\cf0 {\listtext	\'95	}NEW - We've used "KALITE_PEX" environment variables to get the path of `kalite.pex` executable.\
+{\listtext	\'95	}NEW - We've used bundled `kalite.pex` executable.\
+{\listtext	\'95	}NEW - KA Lite application will not start if port 8008 is not available.\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 
 \b \cf0 \ul \
+\pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 
-\b0 \ulnone \
+\b0 \cf0 \ulnone \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 
 \b \cf0 Help and Logs
@@ -102,7 +62,8 @@ If you encounter issues, please file them at the KA Lite Installers repository -
 \
 Please note that we have tested this application on the following Mac OS X versions:\
 \pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural\partightenfactor0
-\ls5\ilvl0\cf0 {\listtext	\'95	}OS X El Capitan - version 10.11.3\
+\ls4\ilvl0\cf0 {\listtext	\'95	}macOS Sierra -version 10.12.2\
+\ls4\ilvl0{\listtext	\'95	}OS X El Capitan - version 10.11.3\
 {\listtext	\'95	}OS X Yosemite - version 10.10.5\
 {\listtext	\'95	}OS X Mavericks - version 10.9.5\
 }

--- a/osx/KA-Lite-Packages/docs/README.rst.rtf
+++ b/osx/KA-Lite-Packages/docs/README.rst.rtf
@@ -26,7 +26,7 @@ Other known issues:\
 \b0 \
 \pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural\partightenfactor0
 \ls2\ilvl0\cf0 {\listtext	\'95	}NEW - We now support macOS Sierra.\
-{\listtext	\'95	}NEW - We now require Python version 2.7.12 or higher to install KA Lite.\
+{\listtext	\'95	}NEW - We now require Python version 2.7.12 or higher except Python 3.x.x to install KA Lite.\
 \pard\tx220\tx720\tx1120\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural\partightenfactor0
 \ls2\ilvl0\cf0 {\listtext	\'95	}REMOVED - We removed `Pyrun` from the KA Lite installer.\
 \pard\tx566\tx1120\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
@@ -38,15 +38,14 @@ Other known issues:\
 \b0 \
 \
 \pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural\partightenfactor0
-\ls3\ilvl0\cf0 {\listtext	\'95	}NEW - We've used "KALITE_PEX" environment variable to get the path of `kalite.pex` executable.\
-{\listtext	\'95	}NEW - We've used bundled `kalite.pex` executable.\
+\ls3\ilvl0\cf0 {\listtext	\'95	}NEW - We now use "KALITE_PEX" environment variable to get the path of `kalite.pex` executable\
+{\listtext	\'95	}NEW - We now use bundled `kalite.pex` executable.\
 {\listtext	\'95	}NEW - KA Lite application will not start if port 8008 is not available.\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 
 \b \cf0 \ul \
-\pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 
-\b0 \cf0 \ulnone \
+\b0 \ulnone \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 
 \b \cf0 Help and Logs
@@ -61,9 +60,10 @@ You can open `~/.kalite/server.log` to view access and debug logs of the KA Lite
 If you encounter issues, please file them at the KA Lite Installers repository - https://github.com/learningequality/installers or at the KA Lite repository - https://github.com/learningequality/ka-lite/issues/.\
 \
 Please note that we have tested this application on the following Mac OS X versions:\
+\
 \pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural\partightenfactor0
-\ls4\ilvl0\cf0 {\listtext	\'95	}macOS Sierra -version 10.12.2\
-\ls4\ilvl0{\listtext	\'95	}OS X El Capitan - version 10.11.3\
+\ls4\ilvl0\cf0 {\listtext	\'95	}macOS Sierra - version 10.12.2\
+{\listtext	\'95	}OS X El Capitan - version 10.11.3\
 {\listtext	\'95	}OS X Yosemite - version 10.10.5\
 {\listtext	\'95	}OS X Mavericks - version 10.9.5\
 }

--- a/osx/KA-Lite/KA-Lite/README.md
+++ b/osx/KA-Lite/KA-Lite/README.md
@@ -6,20 +6,20 @@ This is the Xcode project for the KA Lite application.
 
 ## Requirements
 
-Xcode 6.x or 7.x
+Xcode 7.2
 Mac OS X Yosemite or El Capitan
 
 
 ## Features
 
 1. Show status icon at the menu bar.
-1. It uses the `/usr/local/bin/kalite` executable to interface with the KA Lite server.
+1. It uses the `KALITE_PEX` environment variable to interface with the KA Lite server.
 1. Provide menu to Start KA Lite, Stop KA Lite, and open KA Lite in browser.
 1. Preferences dialog for admin tasks like setting a custom KA Lite data path.
 1. Logs messages so they are accessible at the Logs tab of the Preferences dialog and the Console app.
 
 
 ## Notes:
-
-* The application will not load if the `/usr/local/bin/kalite` executable cannot be found.
+* The application will not load if the `kalite.pex` executable cannot be found.
 * Refer to the `osx/release-docs/README.md` document for more details.
+* The application uses `KALITE_PEX` environment variable to get the path of `kalite.pex` executable and if the environment will not exist, it will default to "/Applications/KA-Lite/support/ka-lite/kalite.pex".

--- a/osx/KA-Lite/KA-Lite/README.md
+++ b/osx/KA-Lite/KA-Lite/README.md
@@ -6,7 +6,7 @@ This is the Xcode project for the KA Lite application.
 
 ## Requirements
 
-Xcode 7.2
+Xcode 7.2 or higher 
 Mac OS X Yosemite or El Capitan
 
 

--- a/osx/KA-Lite/KA-Lite/README.md
+++ b/osx/KA-Lite/KA-Lite/README.md
@@ -22,4 +22,4 @@ Mac OS X Yosemite or El Capitan
 ## Notes:
 * The application will not load if the `kalite.pex` executable cannot be found.
 * Refer to the `osx/release-docs/README.md` document for more details.
-* The application uses `KALITE_PEX` environment variable to get the path of `kalite.pex` executable and if the environment will not exist, it will default to "/Applications/KA-Lite/support/ka-lite/kalite.pex".
+* The application uses `KALITE_PEX` environment variable to get the path of `kalite.pex` executable and if it does not exist it will default to "/Applications/KA-Lite/support/ka-lite/kalite.pex".

--- a/osx/README.md
+++ b/osx/README.md
@@ -8,10 +8,10 @@ The application icon sits on the menu bar of OS X and uses PEX to isolate the KA
 ## System Requirements
 
 * Mac OS X 10.10 Yosemite or newer
-* Xcode 7.3
+* Xcode 7.2 or higher
 * git
 * wget
-* [Python 2.7.11+](https://www.python.org/)
+* [Python 2.7.12](https://www.python.org/)
 * [PEX](https://pex.readthedocs.io/en/stable/)
 * [Packages](http://s.sudre.free.fr/Software/Packages/about.html) by Stéphane Sudre
 * [KA Lite](https://github.com/learningequality/ka-lite/wiki/Getting-started) - optional but recommended

--- a/osx/dmg-resources/README.md
+++ b/osx/dmg-resources/README.md
@@ -1,7 +1,7 @@
 KA Lite OS X installer
 ======================
 
-## [KA Lite OS X installer](http://pantry.learningequality.org/downloads/ka-lite/0.17/installers/mac/KA-Lite-Installers.dmg) required a minimum of Python version 2.7.11.
+## [KA Lite OS X installer](http://pantry.learningequality.org/downloads/ka-lite/0.17/installers/mac/KA-Lite-Installer.dmg) required a minimum of Python version 2.7.12 or higher except Python 3.0.0.
 
 ## To check the Python version in your system.
 * Open a terminal from the utilities folder on your system.

--- a/osx/dmg-resources/README.md
+++ b/osx/dmg-resources/README.md
@@ -1,7 +1,7 @@
 KA Lite OS X installer
 ======================
 
-## [KA Lite OS X installer](http://pantry.learningequality.org/downloads/ka-lite/0.17/installers/mac/KA-Lite-Installer.dmg) required a minimum of Python version 2.7.12 or higher except Python 3.0.0.
+## [KA Lite OS X installer](http://pantry.learningequality.org/downloads/ka-lite/0.17/installers/mac/KA-Lite-Installer.dmg) required a minimum of Python version 2.7.12 or higher except Python 3.x.x
 
 ## To check the Python version in your system.
 * Open a terminal from the utilities folder on your system.

--- a/osx/release-docs/README.md
+++ b/osx/release-docs/README.md
@@ -12,7 +12,7 @@ It uses [PEX](https://pex.readthedocs.io/en/stable/) to create `kalite.pex` exec
 
 1. Download the [KA Lite Mac OS X Installer for 0.17](http://pantry.learningequality.org/downloads/ka-lite/0.17/installers/mac/).
 1. Double-click the downloaded `KA-lite-Installer.dmg`.
-1. KA Lite Mac OS X Installer required Python 2.7.11+. If you're not sure the version of python installed in your machine, double-click README.md for the instructions.
+1. KA Lite Mac OS X Installer required Python 2.7.12 or higher versions. If you're not sure the version of python installed in your machine, double-click README.md for the instructions.
 1. Double-click the `KA-Lite.pkg` package and click "Continue" when prompted about the "This package will run a program to determine if the software can be installed." message.
 1. Follow the setup wizard.  The installation requires admin privileges.
 1. This package will run a program to determine if the software can be installed.
@@ -76,6 +76,7 @@ Please note that we have tested this application on the following Mac OS X versi
 * OS X El Capitan - version 10.11.3
 * OS X Yosemite - version 10.10.5
 * OS X Mavericks - version 10.9.5
+* macOS Sierra -version 10.12.2
 
 
 ## ToDos

--- a/osx/release-docs/README.md
+++ b/osx/release-docs/README.md
@@ -73,10 +73,10 @@ If you encounter issues, please file them at the [KA Lite repository](https://gi
 
 Please note that we have tested this application on the following Mac OS X versions:
 
+* macOS Sierra -version 10.12.2
 * OS X El Capitan - version 10.11.3
 * OS X Yosemite - version 10.10.5
 * OS X Mavericks - version 10.9.5
-* macOS Sierra -version 10.12.2
 
 
 ## ToDos

--- a/osx/release-docs/README.md
+++ b/osx/release-docs/README.md
@@ -12,7 +12,7 @@ It uses [PEX](https://pex.readthedocs.io/en/stable/) to create `kalite.pex` exec
 
 1. Download the [KA Lite Mac OS X Installer for 0.17](http://pantry.learningequality.org/downloads/ka-lite/0.17/installers/mac/).
 1. Double-click the downloaded `KA-lite-Installer.dmg`.
-1. KA Lite Mac OS X Installer required Python 2.7.12 or higher versions. If you're not sure the version of python installed in your machine, double-click README.md for the instructions.
+1. KA Lite Mac OS X Installer required Python 2.7.12 or higher versions. If you're not sure which version of Python is installed in your machine, double-click README.md for the instructions.
 1. Double-click the `KA-Lite.pkg` package and click "Continue" when prompted about the "This package will run a program to determine if the software can be installed." message.
 1. Follow the setup wizard.  The installation requires admin privileges.
 1. This package will run a program to determine if the software can be installed.
@@ -73,7 +73,7 @@ If you encounter issues, please file them at the [KA Lite repository](https://gi
 
 Please note that we have tested this application on the following Mac OS X versions:
 
-* macOS Sierra -version 10.12.2
+* macOS Sierra - version 10.12.2
 * OS X El Capitan - version 10.11.3
 * OS X Yosemite - version 10.10.5
 * OS X Mavericks - version 10.9.5

--- a/osx/release-docs/README.md
+++ b/osx/release-docs/README.md
@@ -5,13 +5,15 @@ This is the [KA Lite](https://github.com/learningequality/ka-lite/) application 
 
 It is used to control and monitor the [KA Lite](https://github.com/learningequality/ka-lite/) server by [Foundation for Learning Equality](https://learningequality.org/).
 
-It uses [PyRun](http://www.egenix.com/products/python/PyRun/) to isolate the KA Lite environment from your system's [Python](https://www.python.org/) application.
+It uses [PEX](https://pex.readthedocs.io/en/stable/) to create `kalite.pex` executable.
 
 
 ## Install KA Lite
 
-1. Download the [KA Lite Mac OS X Installer for 0.16](http://pantry.learningequality.org/downloads/ka-lite/0.16/installers/mac/).
-1. Double-click the downloaded `KA-Lite.pkg` package and click "Continue" when prompted about the "This package will run a program to determine if the software can be installed." message.
+1. Download the [KA Lite Mac OS X Installer for 0.17](http://pantry.learningequality.org/downloads/ka-lite/0.17/installers/mac/).
+1. Double-click the downloaded `KA-lite-Installer.dmg`.
+1. KA Lite Mac OS X Installer required Python 2.7.11+. If you're not sure the version of python installed in your machine, double-click README.md for the instructions.
+1. Double-click the `KA-Lite.pkg` package and click "Continue" when prompted about the "This package will run a program to determine if the software can be installed." message.
 1. Follow the setup wizard.  The installation requires admin privileges.
 1. This package will run a program to determine if the software can be installed.
 1. The installer will create the `/Applications/KA-Lite/` folder that contains the KA-Lite application, uninstall tool, licence, readme, release notes, and the support folder.
@@ -67,7 +69,7 @@ To view the KA Lite installer and application logs, launch the `Console` applica
 
 To view the KA Lite web server logs, open `~/.kalite/server.log` to view access and debug logs.  If you have set a custom KA Lite data folder in the Preferences dialog, use this format: `$KALITE_HOME/server.log`.
 
-If you encounter issues, please file them at the [KA Lite repository](https://github.com/learningequality/ka-lite/issues/) or at the [KA Lite Installers repository](https://github.com/learningequality/installers).
+If you encounter issues, please file them at the [KA Lite repository](https://github.com/learningequality/ka-lite/issues/) or at the [KA Lite Installers repository](https://github.com/learningequality/ka-lite-installers/issues/).
 
 Please note that we have tested this application on the following Mac OS X versions:
 

--- a/osx/release-docs/RELEASE_NOTES.md
+++ b/osx/release-docs/RELEASE_NOTES.md
@@ -6,11 +6,11 @@ Release Notes for KA Lite Mac OS X Application
 
 **Mac Installer**
 
-* NEW - We now support Mac OS Sierra.
-* NEW - We now required Python 2.7.11+ installed on your machine to install KA Lite.
-* NEW - Add Python 2.7.12 to KA-Lite-installer.dmg.
+* NEW - We now support macOS Sierra.
+* NEW - We now require Python 2.7.12 or higher versions to install KA Lite.
+* NEW - Add Python 2.7.12 installer to KA-Lite-installer.dmg.
 * NEW - Add README.md to KA-Lite-installer.dmg.
-* NEW - Move KA-Lite.pkg into KA-Lite-installer.dmg.
+* NEW - Move KA-Lite.pkg installer into KA-Lite-installer.dmg.
 * NEW - Add `kalite.pex` to KA-Lite.pkg.
 * REMOVED - We removed `Pyrun` from the KA Lite installer.
 

--- a/osx/release-docs/RELEASE_NOTES.md
+++ b/osx/release-docs/RELEASE_NOTES.md
@@ -1,6 +1,28 @@
 Release Notes for KA Lite Mac OS X Application
 ==============================================
 
+0.17.0
+------
+
+**Mac Installer**
+
+* NEW - We now support Mac OS Sierra.
+* NEW - We now required Python 2.7.11+ installed on your machine to install KA Lite.
+* NEW - Add Python 2.7.12 to KA-Lite-installer.dmg.
+* NEW - Add README.md to KA-Lite-installer.dmg.
+* NEW - Move KA-Lite.pkg into KA-Lite-installer.dmg.
+* NEW - Add `kalite.pex` to KA-Lite.pkg.
+* REMOVED - We removed `Pyrun` from the KA Lite installer.
+
+**Mac Application**
+* NEW - We've used "KALITE_PEX" environment variables to get the path of `kalite.pex` executable
+* NEW - We've used bundled `kalite.pex` executable.
+* NEW - KA Lite application will not start if port 8008 is not available.
+
+**KA Lite**
+* NEW - We've used [PEX](https://pex.readthedocs.io/en/stable/) to create `kalite.pex` executable.
+
+
 0.16.0
 ------
 

--- a/osx/release-docs/RELEASE_NOTES.md
+++ b/osx/release-docs/RELEASE_NOTES.md
@@ -9,7 +9,7 @@ Release Notes for KA Lite Mac OS X Application
 * NEW - We now support macOS Sierra.
 * NEW - We now require Python version 2.7.12 or higher except Python 3.x.x to install KA Lite.
 * NEW - Add Python 2.7.12 installer to KA-Lite-Installer.dmg.
-* NEW - Add README.md to KA-Lite-installer.dmg.
+* NEW - Add README.md to KA-Lite-Installer.dmg.
 * NEW - Move KA-Lite.pkg installer into KA-Lite-Installer.dmg.
 * NEW - Add `kalite.pex` to KA-Lite.pkg.
 * REMOVED - We removed `Pyrun` from the KA Lite installer.

--- a/osx/release-docs/RELEASE_NOTES.md
+++ b/osx/release-docs/RELEASE_NOTES.md
@@ -7,20 +7,20 @@ Release Notes for KA Lite Mac OS X Application
 **Mac Installer**
 
 * NEW - We now support macOS Sierra.
-* NEW - We now require Python 2.7.12 or higher versions to install KA Lite.
-* NEW - Add Python 2.7.12 installer to KA-Lite-installer.dmg.
+* NEW - We now require Python version 2.7.12 or higher except Python 3.x.x to install KA Lite.
+* NEW - Add Python 2.7.12 installer to KA-Lite-Installer.dmg.
 * NEW - Add README.md to KA-Lite-installer.dmg.
-* NEW - Move KA-Lite.pkg installer into KA-Lite-installer.dmg.
+* NEW - Move KA-Lite.pkg installer into KA-Lite-Installer.dmg.
 * NEW - Add `kalite.pex` to KA-Lite.pkg.
 * REMOVED - We removed `Pyrun` from the KA Lite installer.
 
 **Mac Application**
-* NEW - We've used "KALITE_PEX" environment variables to get the path of `kalite.pex` executable
-* NEW - We've used bundled `kalite.pex` executable.
+* NEW - We now use "KALITE_PEX" environment variable to get the path of `kalite.pex` executable
+* NEW - We now use bundled `kalite.pex` executable.
 * NEW - KA Lite application will not start if port 8008 is not available.
 
 **KA Lite**
-* NEW - We've used [PEX](https://pex.readthedocs.io/en/stable/) to create `kalite.pex` executable.
+* NEW - We now use [PEX](https://pex.readthedocs.io/en/stable/) to create `kalite.pex` executable.
 
 
 0.16.0


### PR DESCRIPTION
## Summary

> I updated the README.md and the release notes for 0.17.x release.


/cc @cpauya @mrpau-eduard 