### PR TITLE
KA Lite server taking so long to start on El Capitán

### DIFF
--- a/osx/KA-Lite/KA-Lite/AppDelegate.h
+++ b/osx/KA-Lite/KA-Lite/AppDelegate.h
@@ -31,10 +31,10 @@
 @property (strong, nonatomic) NSStatusItem *openItem;
 @property (unsafe_unretained) IBOutlet NSTextView *taskLogs;
 
-// It will increment if port 8008 is not available.
-@property signed int portAlertCounter;
-// It will increment when startFunction() will execute.
-@property signed int kaliteStartCounter;
+// It will set as YES if port 8008 is not available.
+@property BOOL isPortAlert;
+// It will set as YES when startFunction() will execute.
+@property BOOL iskaliteStart;
 
 @property BOOL isLoaded;
 @property BOOL autoStartOnLoad;

--- a/osx/KA-Lite/KA-Lite/AppDelegate.h
+++ b/osx/KA-Lite/KA-Lite/AppDelegate.h
@@ -30,8 +30,12 @@
 @property (strong, nonatomic) NSStatusItem *stopItem;
 @property (strong, nonatomic) NSStatusItem *openItem;
 @property (unsafe_unretained) IBOutlet NSTextView *taskLogs;
-@property signed int kaliteProcessCounter;
+
+// It will increment if port 8008 is not available.
 @property signed int portAlertCounter;
+// It will increment when startFunction() will execute.
+@property signed int kaliteStartCounter;
+
 @property BOOL isLoaded;
 @property BOOL autoStartOnLoad;
 @property NSString *version;

--- a/osx/KA-Lite/KA-Lite/AppDelegate.m
+++ b/osx/KA-Lite/KA-Lite/AppDelegate.m
@@ -268,7 +268,7 @@ BOOL isKaliteCommand(NSString *command) {
     
     if (!isKaliteCommand(lastCommandArg)) {
         if (status == statusOkRunning) {
-            self.portAlertCounter += 1;
+            self.isPortAlert = YES;
         }
         [self getKaliteStatus];
         return self.status;
@@ -279,19 +279,19 @@ BOOL isKaliteCommand(NSString *command) {
         if ([lastCommandArg isEqualToString: @"status"]) {
             
             //Check if KA Lite port 8008 is open.
-            if ((self.portAlertCounter == 1) && (status != statusOkRunning)){
-                self.portAlertCounter -= 1;
+            if ((self.isPortAlert) && (status != statusOkRunning)){
+                self.isPortAlert = NO;
                 alert(@"Port :8008 is occupied. Please close the process that is using it to start the KA Lite.");
                 [self setNewStatus:statusStopped];
                 [self showStatus:statusStopped];
                 return self.status;
             } else {
-                if (self.portAlertCounter == 1) {
-                    self.portAlertCounter -= 1;
+                if (self.isPortAlert) {
+                    self.isPortAlert = NO;
                 }
                 // This will run `kalite start` command after checking the port 8008.
-                if (self.kaliteStartCounter == 1) {
-                    self.kaliteStartCounter = statusOkRunning;
+                if (self.iskaliteStart) {
+                    self.iskaliteStart = NO;
                     [self setNewStatus:statusStartingUp];
                     [self runKalite:@"start"];
                     
@@ -615,7 +615,7 @@ NSString *getEnvVar(NSString *var) {
     // Check if port 8008 is running.
     [self runTask:[NSString stringWithFormat:@"lsof -i :%d", kalitePort]];
     // `kalite start` command will execute if port 8008 is available.
-    self.kaliteStartCounter += 1;
+    self.iskaliteStart = YES;
     [self.startKalite setEnabled:NO];
 }
 


### PR DESCRIPTION
## Summary

This fixes KA Lite server taking so long to start on El Capitán when using the latest English content packs with subs.


##

Hi @radinamatic can you test again, the latest OS X [installer](https://drive.google.com/open?id=0B5Tyi-tRKOFMVmhwTHpmOHVQVHM) with the updated English content pack. 

/cc @radinamatic  @cpauya @mrpau-eduard 