### PR TITLE
Fix not loading English content pack with subtitles using the KA Lite windows application.

### DIFF
--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -470,6 +470,7 @@ var
 begin
     { Used to have more responsibility, but we delegated those to the app itself! }
     { Unpacks the English content pack. }
+    Exec(ExpandConstant('{cmd}'), '/S /C "' + ExpandConstant('"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat"') + ' manage syncdb --noinput"', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, retCode);
     Exec(ExpandConstant('{cmd}'), '/S /C "' + ExpandConstant('"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat"') + ' manage retrievecontentpack local en en.zip --foreground"', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, retCode);
 end;
 


### PR DESCRIPTION
## Summary
> This fixes the issue when newly build English content pack with subtitles are not showing in the KA Lite windows application. 


Hi @radinamatic Can you test this using this [windows installer](https://drive.google.com/open?id=0B5Tyi-tRKOFMaUwtdXJnSC1jdmc).


/cc @cpauya  @mrpau-eduard 