### PR TITLE
Fixing systemd

### DIFF
--- a/debian/debian/changelog
+++ b/debian/debian/changelog
@@ -1,3 +1,9 @@
+ka-lite-source (0.17.0-0ubuntu2) trusty; urgency=medium
+
+  * Rebuild with systemd fix
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Sun, 19 Mar 2017 10:39:42 +0100
+
 ka-lite-source (0.17.0-0ubuntu1) trusty; urgency=medium
 
   * New upstream release

--- a/debian/debian/ka-lite.service
+++ b/debian/debian/ka-lite.service
@@ -1,5 +1,5 @@
-# The below was copied from an auto-generated file made
-# by systemd-sysv-generator
+# This provides the KA Lite service, started by invoking the old
+# style /etc/init.d/ka-lite service for backwards-compatibility.
 
 [Unit]
 SourcePath=/etc/init.d/ka-lite
@@ -10,10 +10,13 @@ Wants=network-online.target
 [Service]
 Type=forking
 Restart=no
-TimeoutSec=5min
+TimeoutStartSec=infinity
 IgnoreSIGPIPE=no
 KillMode=process
 GuessMainPID=no
 RemainAfterExit=yes
 ExecStart=/etc/init.d/ka-lite start
 ExecStop=/etc/init.d/ka-lite stop
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Lacking a mandatory section, obviously because the auto-generated file, I copied was broken.

Systemd is becoming the standard on most major distros, so we better be up to speed. Also this for consideration: https://twitter.com/systemdsucks

## Summary

Tested in Ubuntu 16.04


## Issues addressed

https://github.com/learningequality/ka-lite/issues/5423


## TODO

> PR is considered WIP (work in progress), until all TODOs are marked.

- [x] Added/updated the documentation.
- [x] Updated installer's local changelog
- [x] Verified test builds

