### PR TITLE
Fix hardcoded KA Lite version at mac OS X installer.

### DIFF
--- a/osx/KA-Lite-Packages/docs/INTRODUCTION.rst.rtfd/TXT.rtf
+++ b/osx/KA-Lite-Packages/docs/INTRODUCTION.rst.rtfd/TXT.rtf
@@ -10,7 +10,7 @@
 \cf0 {{\NeXTGraphic ka-lite-logo-horizontal.png \width4848 \height1168
 }¬}\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural\qc\partightenfactor0
 \cf0 \
-version 0.17.0\
+version KA_LITE_VERSION\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\qc\partightenfactor0
 \cf0 \
 \

--- a/osx/KA-Lite-Packages/docs/INTRODUCTION.rst.rtfd/TXT.rtf
+++ b/osx/KA-Lite-Packages/docs/INTRODUCTION.rst.rtfd/TXT.rtf
@@ -10,7 +10,7 @@
 \cf0 {{\NeXTGraphic ka-lite-logo-horizontal.png \width4848 \height1168
 }¬}\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural\qc\partightenfactor0
 \cf0 \
-version KA_LITE_VERSION\
+version {{ KA_LITE_VERSION }}\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\qc\partightenfactor0
 \cf0 \
 \

--- a/osx/KA-Lite-Packages/docs/README.rst.rtf
+++ b/osx/KA-Lite-Packages/docs/README.rst.rtf
@@ -9,7 +9,7 @@
 \margl1440\margr1440\vieww28220\viewh16280\viewkind0
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 
-\f0\b\fs24 \cf0 \ul \ulc0 Release Notes for KA Lite KA_LITE_VERSION
+\f0\b\fs24 \cf0 \ul \ulc0 Release Notes for KA Lite {{ KA_LITE_VERSION }}
 \b0 \ulnone \
 \
 Python 2.7.10 is no longer supported. It *may* still work, but we are no longer actively supporting it.\

--- a/osx/KA-Lite-Packages/docs/README.rst.rtf
+++ b/osx/KA-Lite-Packages/docs/README.rst.rtf
@@ -9,7 +9,7 @@
 \margl1440\margr1440\vieww28220\viewh16280\viewkind0
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 
-\f0\b\fs24 \cf0 \ul \ulc0 Release Notes for KA Lite 0.17.0
+\f0\b\fs24 \cf0 \ul \ulc0 Release Notes for KA Lite KA_LITE_VERSION
 \b0 \ulnone \
 \
 Python 2.7.10 is no longer supported. It *may* still work, but we are no longer actively supporting it.\

--- a/osx/KA-Lite-Packages/docs/SUMMARY.rtfd/TXT.rtf
+++ b/osx/KA-Lite-Packages/docs/SUMMARY.rtfd/TXT.rtf
@@ -9,7 +9,7 @@
 \cf0 {{\NeXTGraphic ka-lite-logo-horizontal.png \width4848 \height1168
 }¬}\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\sl264\slmult1\pardirnatural\qc\partightenfactor0
 \cf0 \
-version KA_LITE_VERSION\
+version {{ KA_LITE_VERSION }}\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\sl264\slmult1\pardirnatural\qc\partightenfactor0
 \cf0 \
 Copyright (c) 2016 Learning Equality\

--- a/osx/KA-Lite-Packages/docs/SUMMARY.rtfd/TXT.rtf
+++ b/osx/KA-Lite-Packages/docs/SUMMARY.rtfd/TXT.rtf
@@ -9,7 +9,7 @@
 \cf0 {{\NeXTGraphic ka-lite-logo-horizontal.png \width4848 \height1168
 }¬}\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\sl264\slmult1\pardirnatural\qc\partightenfactor0
 \cf0 \
-version 0.17.0\
+version KA_LITE_VERSION\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\sl264\slmult1\pardirnatural\qc\partightenfactor0
 \cf0 \
 Copyright (c) 2016 Learning Equality\

--- a/osx/build.sh
+++ b/osx/build.sh
@@ -373,9 +373,9 @@ fi
 echo "Updating KA Lite installer version"
 KA_LITE_VERSION="$(kalite --version)"
 DOCS_PATH="$SCRIPTPATH/KA-Lite-Packages/docs"
-sed -i '' "13s/0.17.0/$KA_LITE_VERSION/g" "$DOCS_PATH/INTRODUCTION.rst.rtfd/TXT.rtf"
-sed -i '' "12s/0.17.0/$KA_LITE_VERSION/g" "$DOCS_PATH/SUMMARY.rtfd/TXT.rtf"
-sed -i '' "12s/0.17.0/$KA_LITE_VERSION/g" "$DOCS_PATH/README.rst.rtf"
+sed -i '' "13s/KA_LITE_VERSION/$KA_LITE_VERSION/g" "$DOCS_PATH/INTRODUCTION.rst.rtfd/TXT.rtf" && \
+sed -i '' "12s/KA_LITE_VERSION/$KA_LITE_VERSION/g" "$DOCS_PATH/SUMMARY.rtfd/TXT.rtf" && \
+sed -i '' "12s/KA_LITE_VERSION/$KA_LITE_VERSION/g" "$DOCS_PATH/README.rst.rtf"
 if [ $? -ne 0 ]; then
     echo ".. Failed to update KA Lite installer version."
 fi

--- a/osx/build.sh
+++ b/osx/build.sh
@@ -373,9 +373,9 @@ fi
 echo "Updating KA Lite installer version"
 KA_LITE_VERSION="$(kalite --version)"
 DOCS_PATH="$SCRIPTPATH/KA-Lite-Packages/docs"
-sed -i '' "13s/KA_LITE_VERSION/$KA_LITE_VERSION/g" "$DOCS_PATH/INTRODUCTION.rst.rtfd/TXT.rtf" && \
-sed -i '' "12s/KA_LITE_VERSION/$KA_LITE_VERSION/g" "$DOCS_PATH/SUMMARY.rtfd/TXT.rtf" && \
-sed -i '' "12s/KA_LITE_VERSION/$KA_LITE_VERSION/g" "$DOCS_PATH/README.rst.rtf"
+sed -i '' "13s/{{ KA_LITE_VERSION }}/$KA_LITE_VERSION/g" "$DOCS_PATH/INTRODUCTION.rst.rtfd/TXT.rtf" && \
+sed -i '' "12s/{{ KA_LITE_VERSION }}/$KA_LITE_VERSION/g" "$DOCS_PATH/SUMMARY.rtfd/TXT.rtf" && \
+sed -i '' "12s/{{ KA_LITE_VERSION }}/$KA_LITE_VERSION/g" "$DOCS_PATH/README.rst.rtf"
 if [ $? -ne 0 ]; then
     echo ".. Failed to update KA Lite installer version."
 fi

--- a/osx/build.sh
+++ b/osx/build.sh
@@ -25,7 +25,7 @@
 # 8. Upgrade Python Pip
 # 9. Run `pip install -r requirements_dev.txt` to install the Makefile executables.
 # 10. Installing PEX to create kalite PEX file
-# 11. Update installer version
+# 11. Update KA Lite installer version.
 # 12. Run `make dist` for assets and docs.
 # 13. Build the Xcode project.
 # 14. Code-sign the built .app if running on build server.

--- a/osx/build.sh
+++ b/osx/build.sh
@@ -25,11 +25,12 @@
 # 8. Upgrade Python Pip
 # 9. Run `pip install -r requirements_dev.txt` to install the Makefile executables.
 # 10. Installing PEX to create kalite PEX file
-# 11. Run `make dist` for assets and docs.
-# 12. Build the Xcode project.
-# 13. Code-sign the built .app if running on build server.
-# 14. Run Packages script to build the .pkg.
-# 15. Build the dmg file.
+# 11. Update installer version
+# 12. Run `make dist` for assets and docs.
+# 13. Build the Xcode project.
+# 14. Code-sign the built .app if running on build server.
+# 15. Run Packages script to build the .pkg.
+# 16. Build the dmg file.
 
 
 # REF: Bash References
@@ -49,7 +50,7 @@
 # . spctl --assess --type install KA-Lite.pkg
 
 STEP=0
-STEPS=15
+STEPS=16
 
 # TODO(cpauya): get version from `ka-lite/kalite/version.py`
 # Set the default value to `develop` as suggested by [@benjaoming](https://github.com/learningequality/ka-lite-installers/pull/433#discussion_r96399812), so we can use the VERSION environment in bamboo settings. 
@@ -366,6 +367,17 @@ pex -o dist/kalite.pex -m kalite $WHL_FILE
 if [ $? -ne 0 ]; then
     echo ".. Abort! Failed to build KA Lite pex file."
     exit 1
+fi
+
+((STEP++))
+echo "Updating KA Lite installer version"
+KA_LITE_VERSION="$(kalite --version)"
+DOCS_PATH="$SCRIPTPATH/KA-Lite-Packages/docs"
+sed -i '' "13s/0.17.0/$KA_LITE_VERSION/g" "$DOCS_PATH/INTRODUCTION.rst.rtfd/TXT.rtf"
+sed -i '' "12s/0.17.0/$KA_LITE_VERSION/g" "$DOCS_PATH/SUMMARY.rtfd/TXT.rtf"
+sed -i '' "12s/0.17.0/$KA_LITE_VERSION/g" "$DOCS_PATH/README.rst.rtf"
+if [ $? -ne 0 ]; then
+    echo ".. Failed to update KA Lite installer version."
 fi
 
 ENV_CMD="rm -r $ENV_PATH/venv"


### PR DESCRIPTION
## Summary

> This will fix the hardcoded KA Lite version at the `.pkg`  installer.

## Issues addressed

Fixes #426 

