### PR TITLE
Fixing `service ka-lite status` command

### DIFF
--- a/debian/debian/startup/ka-lite.init
+++ b/debian/debian/startup/ka-lite.init
@@ -40,7 +40,7 @@ case "$1" in
     su $KALITE_USER -s /bin/sh -c "$KALITE_COMMAND start $KALITE_OPTS"
     ;;
   status)
-    su $KALITE_USER -s /bin/sh -c "$KALITE_COMMAND status $KALILTE_OPTS"
+    su $KALITE_USER -s /bin/sh -c "$KALITE_COMMAND status $KALITE_OPTS"
     ;;
   *)
     log_success_msg "Usage: /etc/init.d/kalite {start|stop|restart|status}"

--- a/debian/test.sh
+++ b/debian/test.sh
@@ -123,6 +123,8 @@ then
     kalite status
     # Test that the script restarts
     sudo service ka-lite restart
+    # Test that status command is possible
+    sudo service ka-lite status
     sudo -E apt-get purge -y ka-lite-bundle
 
     echo "Done with ka-lite-bundle tests"


### PR DESCRIPTION
## Summary

thanks @jamalex!


## TODO

- [x] Updated installer's local changelog
- [ ] Verified test builds

