### PR TITLE
Installing python with Homebrew fails

### DIFF
--- a/osx/ka-lite-python-version-check.sh
+++ b/osx/ka-lite-python-version-check.sh
@@ -6,12 +6,17 @@ function msg() {
     syslog -s -l alert "KA-Lite: $1"
 }
 
-PYTHON_PATH="/usr/local/bin/python"
+PYTHON_PATH="/usr/local/bin/python2"
 KALITE_REQ_PYTHON='2.7.11'
+
+if ! $PYTHON_PATH --version >/dev/null 2>&1; then
+    PYTHON_PATH="$(which python2)"
+fi
 
 if ! $PYTHON_PATH --version >/dev/null 2>&1; then
     PYTHON_PATH="$(which python)"
 fi
+
 msg "Checking Python path at $PYTHON_PATH"
 PYTHON_VERSION="$($PYTHON_PATH -c 'import platform; print(platform.python_version())')"
 # REF: http://stackoverflow.com/questions/6141581/detect-python-version-in-shell-script

--- a/osx/post_installation.sh
+++ b/osx/post_installation.sh
@@ -36,10 +36,11 @@ KALITE_HOME_PATH="$HOME/.kalite"
 KALITE_UNINSTALL_SCRIPT="KA-Lite_Uninstall.tool"
 KALITE_PEX_PATH="$KALITE_SHARED/ka-lite/kalite.pex"
 
-PYTHON="/usr/local/bin/python"
+PYTHON="$(which python2)"
 if ! $PYTHON --version >/dev/null 2>&1; then
     PYTHON="$(which python)"
 fi
+
 
 SCRIPT_PATH="$KALITE_SHARED/scripts/"
 APPLICATION_PATH="/Applications/KA-Lite"


### PR DESCRIPTION
## Summary

 Used `python2 --version` command  to check the python version installed in the system.
 If that command didn't exist it will default to `python --version`.


## Issues addressed

Fixes #470 

cc\ @cpauya 