### PR TITLE
Remove —foreground at the retrievecontentpack command.

### DIFF
--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -509,7 +509,7 @@ begin
     { Used to have more responsibility, but we delegated those to the app itself! }
     { Unpacks the English content pack. }
     Exec(ExpandConstant('{cmd}'), '/S /C "' + ExpandConstant('"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat"') + ' manage syncdb --noinput"', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, retCode);
-    Exec(ExpandConstant('{cmd}'), '/S /C "' + ExpandConstant('"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat"') + ' manage retrievecontentpack local en en.zip --foreground"', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, retCode);
+    Exec(ExpandConstant('{cmd}'), '/S /C "' + ExpandConstant('"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat"') + ' manage retrievecontentpack local en en.zip"', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, retCode);
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);


### PR DESCRIPTION
## Summary
The command `retrievecontentpack --foreground` was removed on 0.17.5 release.


## Issues addressed

[#5579](https://github.com/learningequality/ka-lite/pull/5579)


## TODO

> PR is considered WIP (work in progress), until all TODOs are marked.

- [x] Added/updated the documentation.
- [x] Updated installer's local changelog
- [x] Verified test builds

